### PR TITLE
Add Linter from GDScript Toolkit for CI

### DIFF
--- a/.gdlintrc
+++ b/.gdlintrc
@@ -1,0 +1,40 @@
+class-definitions-order:
+- tools
+- classnames
+- extends
+- signals
+- enums
+- consts
+- exports
+- pubvars
+- prvvars
+- onreadypubvars
+- onreadyprvvars
+- others
+class-load-variable-name: (([A-Z][a-z0-9]*)+|_?[a-z][a-z0-9]*(_[a-z0-9]+)*) #PASCAL_CASE or SNAKE_CASE
+class-name: ([A-Z][a-z0-9]*)+ #PASCAL_CASE
+class-variable-name: _?[a-z][a-z0-9]*(_[a-z0-9]+)* #SNAKE_CASE
+comparison-with-itself: null
+constant-name: '[A-Z][A-Z0-9]*(_[A-Z0-9]+)*' #CONSTANT_CASE
+disable: []
+duplicated-load: null
+enum-element-name: '[A-Z][A-Z0-9]*(_[A-Z0-9]+)*' #CONSTANT_CASE
+enum-name: ([A-Z][a-z0-9]*)+ #PASCAL_CASE
+expression-not-assigned: null
+function-argument-name: _?[a-z][a-z0-9]*(_[a-z0-9]+)* #SNAKE_CASE
+function-arguments-number: 10
+function-load-variable-name: ([A-Z][a-z0-9]*)+ #PASCAL_CASE
+function-name: (_on_([A-Z][a-z0-9]*)+(_[a-z0-9]+)*|_?[a-z][a-z0-9]*(_[a-z0-9]+)*) #PASCAL_CASE or SNAKE_CASE
+function-variable-name: '[a-z][a-z0-9]*(_[a-z0-9]+)*' #SNAKE_CASE
+load-constant-name: (([A-Z][a-z0-9]*)+|[A-Z][A-Z0-9]*(_[A-Z0-9]+)*) #PASCAL_CASE or CONSTANT_CASE
+loop-variable-name: _?[a-z][a-z0-9]*(_[a-z0-9]+)* #SNAKE_CASE
+max-file-lines: 1000
+max-line-length: 100
+max-public-methods: 20
+mixed-tabs-and-spaces: null
+private-method-call: null
+signal-name: '[a-z][a-z0-9]*(_[a-z0-9]+)*' #SNAKE_CASE
+sub-class-name: _?([A-Z][a-z0-9]*)+ #PASCAL_CASE
+trailing-whitespace: null
+unnecessary-pass: null
+unused-argument: null

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v3.2.0
     hooks:
     -   id: check-added-large-files # Prevent giant files from being committed
     -   id: check-byte-order-marker # Prevents weird UTF-8 encoding edge cases
@@ -14,3 +14,11 @@ repos:
     -   id: end-of-file-fixer # checks for ending with a newline
     -   id: mixed-line-ending # consistent LF or CRLF
     -   id: trailing-whitespace # no trailing whitespace
+
+-   repo: https://github.com/Scony/godot-gdscript-toolkit
+    rev: master
+    hooks:
+    - id: gdlint
+      exclude: addons/.+
+#    - id: gdformat
+#      exclude: addons/.+


### PR DESCRIPTION
This adds a new Workflow that uses the Linter from [GDScript Toolkit](https://github.com/Scony/godot-gdscript-toolkit).

This Tool can check GDScript for the recommended [Code order](https://docs.godotengine.org/en/latest/getting_started/scripting/gdscript/gdscript_styleguide.html#code-order), [Naming Convention](https://docs.godotengine.org/en/latest/getting_started/scripting/gdscript/gdscript_styleguide.html#naming-conventions), and more.

The settings are in the `.gdlintrc` File. Additionally, I commented the Regex Settings with the corresponding Casing (Pascal case, Snake case, and Constant Case)

The Bash Script ignores all Addons, as they may not necessarily follow the Godot Style Guide.
One such example is Gud.